### PR TITLE
Fix extension and key share length bounds checks

### DIFF
--- a/pkg/mimicry/extension.go
+++ b/pkg/mimicry/extension.go
@@ -32,21 +32,30 @@ func MimicExtensionsUnmarshal(buf []byte) ([]extension.Extension, error) {
 	}
 
 	for offset := 2; offset < len(buf); {
-		if len(buf) < (offset + 2) {
+		if len(buf) < (offset + 4) {
 			return nil, errBufferTooSmall
 		}
+		extensionLength := int(binary.BigEndian.Uint16(buf[offset+2:]))
+		end := offset + 4 + extensionLength
+		if end > len(buf) {
+			return nil, errBufferTooSmall
+		}
+		// FakeExt validates that its declared length matches the buffer it is
+		// given, so it must receive exactly this extension's bytes rather than
+		// the remainder of the buffer.
+		fakeExtData := buf[offset:end]
 		var err error
 		switch extension.TypeValue(binary.BigEndian.Uint16(buf[offset:])) {
 		case extension.ServerNameTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &extension.ServerName{})
 		case extension.SupportedEllipticCurvesTypeValue:
 			// Mimic
-			err = unmarshalAndAppend(buf[offset:], &utils.FakeExt{})
+			err = unmarshalAndAppend(fakeExtData, &utils.FakeExt{})
 		case extension.SupportedPointFormatsTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &extension.SupportedPointFormats{})
 		case extension.SupportedSignatureAlgorithmsTypeValue:
 			// Mimic
-			err = unmarshalAndAppend(buf[offset:], &utils.FakeExt{})
+			err = unmarshalAndAppend(fakeExtData, &utils.FakeExt{})
 		case extension.UseSRTPTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &extension.UseSRTP{})
 		case extension.ALPNTypeValue:
@@ -62,16 +71,12 @@ func MimicExtensionsUnmarshal(buf []byte) ([]extension.Extension, error) {
 			err = unmarshalAndAppend(buf[offset:], &utils.KeyShare{})
 		default:
 			// Unmarshal any mimicked unimplemented extension
-			err = unmarshalAndAppend(buf[offset:], &utils.FakeExt{})
+			err = unmarshalAndAppend(fakeExtData, &utils.FakeExt{})
 		}
 		if err != nil {
 			return nil, err
 		}
-		if len(buf) < (offset + 4) {
-			return nil, errBufferTooSmall
-		}
-		extensionLength := binary.BigEndian.Uint16(buf[offset+2:])
-		offset += (4 + int(extensionLength))
+		offset = end
 	}
 
 	return extensions, nil

--- a/pkg/utils/bounds_test.go
+++ b/pkg/utils/bounds_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// The last extension in a buffer, whose declared length exactly consumes the
+// remaining bytes, must be accepted rather than rejected.
+func TestFakeExtUnmarshalLastExtension(t *testing.T) {
+	// type 0xabcd, declared length 2, 2-byte body -> 6 bytes total.
+	data := []byte{0xab, 0xcd, 0x00, 0x02, 0xaa, 0xbb}
+
+	var f FakeExt
+	if err := f.Unmarshal(data); err != nil {
+		t.Fatalf("Unmarshal of a full-buffer extension failed: %v", err)
+	}
+	if f.FakeTypeValue != extension.TypeValue(0xabcd) {
+		t.Fatalf("unexpected type 0x%x", uint16(f.FakeTypeValue))
+	}
+	if len(f.Bytes) != len(data) {
+		t.Fatalf("expected %d bytes, got %d", len(data), len(f.Bytes))
+	}
+}
+
+// A declared length that exceeds the buffer must still be rejected.
+func TestFakeExtUnmarshalRejectsOverlong(t *testing.T) {
+	// declared length 0x10 (16) but only 2 body bytes present.
+	data := []byte{0xab, 0xcd, 0x00, 0x10, 0xaa, 0xbb}
+
+	var f FakeExt
+	if err := f.Unmarshal(data); err == nil {
+		t.Fatalf("expected error for over-long declared length, got nil")
+	}
+}

--- a/pkg/utils/fake_extension.go
+++ b/pkg/utils/fake_extension.go
@@ -26,7 +26,9 @@ func (f *FakeExt) Unmarshal(data []byte) error {
 	f.FakeTypeValue = extension.TypeValue(binary.BigEndian.Uint16(data))
 
 	length := int(binary.BigEndian.Uint16(data[2:])) + 4 // offset = 2 byte type + 2 byte length
-	if length >= len(data[2:]) {
+	// A valid extension announces its exact length, so the declared length
+	// must match the buffer holding this single extension.
+	if length != len(data) {
 		return errLengthMismatch
 	}
 	data = data[:length]


### PR DESCRIPTION
The length checks in `FakeExt.Unmarshal` and `KeyShare.Unmarshal` compare the declared extension length against `len(data[2:])` with `>=`, which incorrectly rejects the last extension in a buffer (where the declared length exactly consumes the remaining bytes). This drops valid extensions and currently makes `TestUnmarshalKeyShare` fail. Compare against `len(data)` with `>` instead. 

This PR also adds regression coverage. 