### PR TITLE
Randomize ServerHello and ec_point_formats extensions

### DIFF
--- a/pkg/mimicry/mimic_client_hello.go
+++ b/pkg/mimicry/mimic_client_hello.go
@@ -21,6 +21,11 @@ type MimickedClientHello struct {
 	Cookie                 []byte
 	SessionID              []byte
 
+	// Rand is the randomness source used to select a fingerprint in
+	// LoadRandomFingerprint. When nil, a crypto/rand-backed source is used.
+	// Supply a seeded Rand to deterministically select the same fingerprint.
+	Rand utils.Rand
+
 	CipherSuiteIDs         []uint16
 	CompressionMethods     []*protocol.CompressionMethod
 	Extensions             []extension.Extension
@@ -51,11 +56,20 @@ func (m *MimickedClientHello) LoadFingerprint(fingerprint fingerprints.ClientHel
 	return err
 }
 
-// Loads a random fingerprint to mimic
+// Loads a random fingerprint to mimic. When Rand is set, the selection is
+// deterministic for a given seed.
 func (m *MimickedClientHello) LoadRandomFingerprint() error {
 	allFingerprints := fingerprints.GetClientHelloFingerprints()
 	length := len(allFingerprints)
-	randomFingerprint := allFingerprints[utils.RandRange(0, length-1)]
+	if length == 0 {
+		return errNoFingerprints
+	}
+
+	r := m.Rand
+	if r == nil {
+		r = utils.DefaultRand()
+	}
+	randomFingerprint := allFingerprints[r.Intn(length)]
 	return m.LoadFingerprint(randomFingerprint)
 }
 

--- a/pkg/mimicry/mimic_random_test.go
+++ b/pkg/mimicry/mimic_random_test.go
@@ -1,0 +1,39 @@
+package mimicry
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// A seeded Rand must make LoadRandomFingerprint select the same fingerprint
+// across runs, which is what enables deterministic replay.
+func TestLoadRandomFingerprintDeterministic(t *testing.T) {
+	load := func(seed int64) string {
+		m := &MimickedClientHello{Rand: rand.New(rand.NewSource(seed))} //nolint:gosec
+		if err := m.LoadRandomFingerprint(); err != nil {
+			t.Fatalf("LoadRandomFingerprint failed: %v", err)
+		}
+		return string(m.clientHelloFingerprint)
+	}
+
+	first := load(2024)
+	second := load(2024)
+	if first == "" {
+		t.Fatalf("no fingerprint loaded")
+	}
+	if first != second {
+		t.Fatalf("seeded selection was not deterministic")
+	}
+}
+
+// With no Rand set, LoadRandomFingerprint must still work using the default
+// crypto/rand source.
+func TestLoadRandomFingerprintDefaultRand(t *testing.T) {
+	m := &MimickedClientHello{}
+	if err := m.LoadRandomFingerprint(); err != nil {
+		t.Fatalf("LoadRandomFingerprint with default Rand failed: %v", err)
+	}
+	if string(m.clientHelloFingerprint) == "" {
+		t.Fatalf("no fingerprint loaded")
+	}
+}

--- a/pkg/randomize/extension.go
+++ b/pkg/randomize/extension.go
@@ -2,12 +2,15 @@ package randomize
 
 import (
 	"encoding/binary"
+
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/theodorsm/covert-dtls/pkg/utils"
 )
 
-// Unmarshal many extensions at once, will randomize use_srtp, signature_algorithms and supported_groups.
-func RandomizeExtensionUnmarshal(buf []byte) ([]extension.Extension, error) {
+// RandomizeExtensionUnmarshal unmarshals many extensions at once, randomizing
+// use_srtp, signature_algorithms and supported_groups using r. Passing a
+// seeded Rand makes the randomization reproducible.
+func RandomizeExtensionUnmarshal(buf []byte, r utils.Rand) ([]extension.Extension, error) {
 	switch {
 	case len(buf) == 0:
 		return []extension.Extension{}, nil
@@ -44,7 +47,7 @@ func RandomizeExtensionUnmarshal(buf []byte) ([]extension.Extension, error) {
 			if err != nil {
 				return nil, err
 			}
-			e.EllipticCurves = utils.ShuffleRandomLength(e.EllipticCurves, true)
+			e.EllipticCurves = utils.ShuffleRandomLength(e.EllipticCurves, true, r)
 			extensions = append(extensions, e)
 		case extension.SupportedPointFormatsTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &extension.SupportedPointFormats{})
@@ -54,7 +57,7 @@ func RandomizeExtensionUnmarshal(buf []byte) ([]extension.Extension, error) {
 			if err != nil {
 				return nil, err
 			}
-			e.SignatureHashAlgorithms = utils.ShuffleRandomLength(e.SignatureHashAlgorithms, true)
+			e.SignatureHashAlgorithms = utils.ShuffleRandomLength(e.SignatureHashAlgorithms, true, r)
 			extensions = append(extensions, e)
 		case extension.UseSRTPTypeValue:
 			e := &extension.UseSRTP{}
@@ -62,7 +65,7 @@ func RandomizeExtensionUnmarshal(buf []byte) ([]extension.Extension, error) {
 			if err != nil {
 				return nil, err
 			}
-			e.ProtectionProfiles = utils.ShuffleRandomLength(e.ProtectionProfiles, true)
+			e.ProtectionProfiles = utils.ShuffleRandomLength(e.ProtectionProfiles, true, r)
 			extensions = append(extensions, e)
 		case extension.ALPNTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &extension.ALPN{})

--- a/pkg/randomize/extension.go
+++ b/pkg/randomize/extension.go
@@ -8,8 +8,8 @@ import (
 )
 
 // RandomizeExtensionUnmarshal unmarshals many extensions at once, randomizing
-// use_srtp, signature_algorithms and supported_groups using r. Passing a
-// seeded Rand makes the randomization reproducible.
+// use_srtp, signature_algorithms, supported_groups and ec_point_formats using
+// r. Passing a seeded Rand makes the randomization reproducible.
 func RandomizeExtensionUnmarshal(buf []byte, r utils.Rand) ([]extension.Extension, error) {
 	switch {
 	case len(buf) == 0:
@@ -50,7 +50,13 @@ func RandomizeExtensionUnmarshal(buf []byte, r utils.Rand) ([]extension.Extensio
 			e.EllipticCurves = utils.ShuffleRandomLength(e.EllipticCurves, true, r)
 			extensions = append(extensions, e)
 		case extension.SupportedPointFormatsTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &extension.SupportedPointFormats{})
+			e := &extension.SupportedPointFormats{}
+			err = e.Unmarshal(buf[offset:])
+			if err != nil {
+				return nil, err
+			}
+			e.PointFormats = utils.ShuffleRandomLength(e.PointFormats, true, r)
+			extensions = append(extensions, e)
 		case extension.SupportedSignatureAlgorithmsTypeValue:
 			e := &extension.SupportedSignatureAlgorithms{}
 			err = e.Unmarshal(buf[offset:])

--- a/pkg/randomize/randomize_client_hello.go
+++ b/pkg/randomize/randomize_client_hello.go
@@ -18,6 +18,11 @@ type RandomizedMessageClientHello struct {
 	Cookie     []byte
 	RandomALPN bool // Add a random ALPN if there is none in the hooked message
 
+	// Rand is the randomness source used for all randomization choices. When
+	// nil, a crypto/rand-backed source is used. Supply a seeded Rand to
+	// deterministically replay the same randomized ClientHello.
+	Rand utils.Rand
+
 	SessionID []byte
 
 	CipherSuiteIDs     []uint16
@@ -32,17 +37,28 @@ func (m RandomizedMessageClientHello) Type() handshake.Type {
 	return handshake.TypeClientHello
 }
 
+// rand returns the configured randomness source, or a crypto/rand-backed
+// default when none was set.
+func (m *RandomizedMessageClientHello) rand() utils.Rand {
+	if m.Rand == nil {
+		return utils.DefaultRand()
+	}
+	return m.Rand
+}
+
 // ClientHello Hook for randomization
 func (m *RandomizedMessageClientHello) Hook(ch handshake.MessageClientHello) handshake.Message {
+	r := m.rand()
+
 	buf, err := ch.Marshal()
 	if err != nil {
 		return &ch
 	}
-	err = m.Unmarshal(buf)
+	err = m.unmarshalWithRand(buf, r)
 	if err != nil {
 		return &ch
 	}
-	m.CipherSuiteIDs = utils.ShuffleRandomLength(m.CipherSuiteIDs, true)
+	m.CipherSuiteIDs = utils.ShuffleRandomLength(m.CipherSuiteIDs, true, r)
 
 	hasALPN := false
 	for _, e := range m.Extensions {
@@ -52,12 +68,12 @@ func (m *RandomizedMessageClientHello) Hook(ch handshake.MessageClientHello) han
 	}
 	if !hasALPN && m.RandomALPN {
 		e := &extension.ALPN{
-			ProtocolNameList: []string{utils.ALPNS[utils.RandRange(0, len(utils.ALPNS)-1)]},
+			ProtocolNameList: []string{utils.ALPNS[r.Intn(len(utils.ALPNS))]},
 		}
 		m.Extensions = append(m.Extensions, e)
 	}
 
-	m.Extensions = utils.ShuffleRandomLength(m.Extensions, false)
+	m.Extensions = utils.ShuffleRandomLength(m.Extensions, false, r)
 	return m
 }
 
@@ -89,8 +105,15 @@ func (m *RandomizedMessageClientHello) Marshal() ([]byte, error) {
 	return append(out, extensions...), nil
 }
 
-// Unmarshal populates the message from encoded data
+// Unmarshal populates the message from encoded data, randomizing extensions
+// with a crypto/rand-backed source or, when set, the configured Rand.
 func (m *RandomizedMessageClientHello) Unmarshal(data []byte) error {
+	return m.unmarshalWithRand(data, m.rand())
+}
+
+// unmarshalWithRand populates the message from encoded data, using r for
+// extension randomization.
+func (m *RandomizedMessageClientHello) unmarshalWithRand(data []byte, r utils.Rand) error {
 	if len(data) < 2+handshake.RandomLength {
 		return errBufferTooSmall
 	}
@@ -156,7 +179,7 @@ func (m *RandomizedMessageClientHello) Unmarshal(data []byte) error {
 	currOffset += int(data[currOffset]) + 1
 
 	// Extensions
-	extensions, err := RandomizeExtensionUnmarshal(data[currOffset:])
+	extensions, err := RandomizeExtensionUnmarshal(data[currOffset:], r)
 	if err != nil {
 		return err
 	}

--- a/pkg/randomize/randomize_server_hello.go
+++ b/pkg/randomize/randomize_server_hello.go
@@ -1,0 +1,37 @@
+package randomize
+
+import (
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/theodorsm/covert-dtls/pkg/utils"
+)
+
+// RandomizedMessageServerHello provides a ServerHello hook that shuffles the
+// order of the ServerHello extensions to avoid trivial extension-order
+// fingerprinting. A ServerHello carries a single cipher suite and fewer
+// extensions than a ClientHello, so only the extension order is randomized.
+//
+// It is intended to be used with pion/dtls' ServerHelloMessageHook (for
+// example via webrtc's SettingEngine.SetDTLSServerHelloMessageHook).
+type RandomizedMessageServerHello struct {
+	// Rand is the randomness source used to shuffle the extension order. When
+	// nil, a crypto/rand-backed source is used. Supply a seeded Rand to
+	// deterministically replay the same extension ordering.
+	Rand utils.Rand
+}
+
+// Hook is the ServerHelloMessageHook callback for pion/dtls. It shuffles the
+// extension order of the ServerHello message.
+func (m *RandomizedMessageServerHello) Hook(sh handshake.MessageServerHello) handshake.Message {
+	r := m.Rand
+	if r == nil {
+		r = utils.DefaultRand()
+	}
+
+	if len(sh.Extensions) > 1 {
+		r.Shuffle(len(sh.Extensions), func(i, j int) {
+			sh.Extensions[i], sh.Extensions[j] = sh.Extensions[j], sh.Extensions[i]
+		})
+	}
+
+	return &sh
+}

--- a/pkg/randomize/randomize_test.go
+++ b/pkg/randomize/randomize_test.go
@@ -68,3 +68,47 @@ func TestRandomizedClientHelloDefaultRand(t *testing.T) {
 		t.Fatalf("Marshal with default Rand failed: %v", err)
 	}
 }
+
+// A seeded Rand must make the ServerHello extension ordering reproducible.
+func TestRandomizedServerHelloDeterministic(t *testing.T) {
+	build := func() handshake.MessageServerHello {
+		return handshake.MessageServerHello{
+			Version: protocol.Version{Major: 0xfe, Minor: 0xfd},
+			Extensions: []extension.Extension{
+				&extension.RenegotiationInfo{},
+				&extension.UseExtendedMasterSecret{},
+				&extension.ALPN{ProtocolNameList: []string{"h2"}},
+				&extension.UseSRTP{
+					ProtectionProfiles: []extension.SRTPProtectionProfile{
+						extension.SRTP_AEAD_AES_128_GCM,
+					},
+				},
+			},
+		}
+	}
+
+	order := func(seed int64) []uint16 {
+		m := &RandomizedMessageServerHello{Rand: rand.New(rand.NewSource(seed))} //nolint:gosec
+		msg := m.Hook(build())
+		sh, ok := msg.(*handshake.MessageServerHello)
+		if !ok {
+			t.Fatalf("Hook returned unexpected type %T", msg)
+		}
+		types := make([]uint16, len(sh.Extensions))
+		for i, e := range sh.Extensions {
+			types[i] = uint16(e.TypeValue())
+		}
+		return types
+	}
+
+	first := order(99)
+	second := order(99)
+	if len(first) != len(second) {
+		t.Fatalf("seeded runs produced different extension counts")
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("seeded ServerHello ordering diverged at %d: %v vs %v", i, first, second)
+		}
+	}
+}

--- a/pkg/randomize/randomize_test.go
+++ b/pkg/randomize/randomize_test.go
@@ -1,0 +1,70 @@
+package randomize
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+)
+
+func testClientHello() handshake.MessageClientHello {
+	return handshake.MessageClientHello{
+		Version:            protocol.Version{Major: 0xfe, Minor: 0xfd},
+		CipherSuiteIDs:     []uint16{0xc02b, 0xc02f, 0xc00a, 0xc009, 0xc013, 0xc014},
+		CompressionMethods: []*protocol.CompressionMethod{{}},
+		Extensions: []extension.Extension{
+			&extension.RenegotiationInfo{},
+			&extension.UseExtendedMasterSecret{},
+			&extension.ALPN{ProtocolNameList: []string{"h2", "http/1.1"}},
+			&extension.UseSRTP{
+				ProtectionProfiles: []extension.SRTPProtectionProfile{
+					extension.SRTP_AES128_CM_HMAC_SHA1_80,
+					extension.SRTP_AES128_CM_HMAC_SHA1_32,
+					extension.SRTP_AEAD_AES_128_GCM,
+					extension.SRTP_AEAD_AES_256_GCM,
+				},
+			},
+		},
+	}
+}
+
+// A seeded Rand must make the randomized ClientHello byte-for-byte
+// reproducible, which is the property tunnel-core relies on for replay.
+func TestRandomizedClientHelloDeterministic(t *testing.T) {
+	marshalWithSeed := func(seed int64) []byte {
+		m := &RandomizedMessageClientHello{
+			RandomALPN: true,
+			Rand:       rand.New(rand.NewSource(seed)), //nolint:gosec
+		}
+		msg := m.Hook(testClientHello())
+		out, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
+		}
+		return out
+	}
+
+	first := marshalWithSeed(1234)
+	second := marshalWithSeed(1234)
+
+	if len(first) != len(second) {
+		t.Fatalf("seeded runs produced different lengths: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("seeded runs diverged at byte %d", i)
+		}
+	}
+}
+
+// With no Rand set, the hook must still function (using the crypto/rand
+// default) and produce a valid, marshalable message.
+func TestRandomizedClientHelloDefaultRand(t *testing.T) {
+	m := &RandomizedMessageClientHello{RandomALPN: true}
+	msg := m.Hook(testClientHello())
+	if _, err := msg.Marshal(); err != nil {
+		t.Fatalf("Marshal with default Rand failed: %v", err)
+	}
+}

--- a/pkg/utils/rand.go
+++ b/pkg/utils/rand.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+// Rand is the source of randomness used by the randomization and mimicry
+// packages. It is intentionally small so that callers can supply their own
+// implementation: passing a seeded, reproducible source enables deterministic
+// replay of a randomized or mimicked handshake, while the default
+// implementation draws from crypto/rand.
+//
+// The interface is satisfied by *math/rand.Rand and by any seeded PRNG that
+// exposes Intn and Shuffle with these signatures.
+type Rand interface {
+	// Intn returns a non-negative pseudo-random int in the half-open interval
+	// [0,n). It panics if n <= 0, matching the semantics of math/rand.Intn.
+	Intn(n int) int
+	// Shuffle pseudo-randomizes the order of n elements, calling swap to swap
+	// the elements with indexes i and j.
+	Shuffle(n int, swap func(i, j int))
+}
+
+// DefaultRand returns a Rand backed by crypto/rand. It is non-deterministic
+// and safe for concurrent use.
+func DefaultRand() Rand {
+	return cryptoRand{}
+}
+
+// cryptoRand is the default Rand implementation, backed by crypto/rand.
+type cryptoRand struct{}
+
+// Intn returns a uniform random int in [0,n). It panics if n <= 0.
+func (cryptoRand) Intn(n int) int {
+	if n <= 0 {
+		panic("utils: Intn requires n > 0")
+	}
+	v, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
+	if err != nil {
+		// crypto/rand.Reader failing is catastrophic and not something a
+		// circumvention handshake can meaningfully recover from.
+		panic(err)
+	}
+	return int(v.Int64())
+}
+
+// Shuffle randomizes the order of n elements using a Fisher-Yates shuffle,
+// matching the semantics of math/rand.Shuffle.
+func (c cryptoRand) Shuffle(n int, swap func(i, j int)) {
+	for i := n - 1; i > 0; i-- {
+		swap(i, c.Intn(i+1))
+	}
+}

--- a/pkg/utils/rand_test.go
+++ b/pkg/utils/rand_test.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// *rand.Rand must satisfy the Rand interface, which is what allows callers to
+// supply a seeded, reproducible randomness source.
+var _ Rand = (*rand.Rand)(nil)
+
+func TestCryptoRandIntn(t *testing.T) {
+	r := DefaultRand()
+	for i := 0; i < 1000; i++ {
+		v := r.Intn(10)
+		if v < 0 || v >= 10 {
+			t.Fatalf("Intn(10) returned out-of-range value %d", v)
+		}
+	}
+}
+
+func TestCryptoRandIntnPanicsOnNonPositive(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("Intn(0) did not panic")
+		}
+	}()
+	DefaultRand().Intn(0)
+}
+
+func TestCryptoRandShuffle(t *testing.T) {
+	// A permutation must preserve the multiset of elements.
+	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	got := make([]int, len(input))
+	copy(got, input)
+	DefaultRand().Shuffle(len(got), func(i, j int) { got[i], got[j] = got[j], got[i] })
+
+	sum := 0
+	for _, v := range got {
+		sum += v
+	}
+	if sum != 55 {
+		t.Fatalf("Shuffle did not preserve elements, sum = %d", sum)
+	}
+}
+
+// A seeded Rand must produce identical ShuffleRandomLength output across runs,
+// which is the property that enables deterministic handshake replay.
+func TestShuffleRandomLengthDeterministic(t *testing.T) {
+	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	first := ShuffleRandomLength(input, true, rand.New(rand.NewSource(42)))  //nolint:gosec
+	second := ShuffleRandomLength(input, true, rand.New(rand.NewSource(42))) //nolint:gosec
+
+	if len(first) != len(second) {
+		t.Fatalf("seeded runs produced different lengths: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("seeded runs diverged at index %d: %v vs %v", i, first, second)
+		}
+	}
+
+	// Input must not be mutated.
+	for i, v := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
+		if input[i] != v {
+			t.Fatalf("ShuffleRandomLength mutated its input at index %d", i)
+		}
+	}
+}

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -7,9 +7,12 @@ import (
 func TestShuffle(t *testing.T) {
 	list := []int{1, 2, 3, 4, 5}
 	for i := 1; i < 1000; i++ {
-		shuffled := ShuffleRandomLength(list, true)
+		shuffled := ShuffleRandomLength(list, true, DefaultRand())
 		if len(shuffled) == 0 {
 			t.Fatalf("Shuffle returned a empty slice")
+		}
+		if len(shuffled) > len(list) {
+			t.Fatalf("Shuffle returned more elements than the input")
 		}
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,9 +5,9 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+
 	"github.com/pion/dtls/v3"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
-	"math/big"
 )
 
 func DefaultSRTPProtectionProfiles() []dtls.SRTPProtectionProfile {
@@ -23,45 +23,38 @@ func DefaultSRTPProtectionProfiles() []dtls.SRTPProtectionProfile {
 	}
 }
 
-func RandRange(min, max int) int {
-	bigRandomNumber, err := rand.Int(rand.Reader, big.NewInt(int64(max+1)))
-	if err != nil {
-		panic(err)
-	}
-	randomNumber := int(bigRandomNumber.Int64())
-	if randomNumber < min {
-		return min
-	}
-	return randomNumber
-}
-
 var ALPNS = []string{"http/1.0", "http/1.1", "h2c", "h2", "h3", "stun.turn", "webrtc", "c-webrtc", "ftp", "pop3", "imap", "mqtt", "smb", "irc", "sip/2"}
 
-func ShuffleRandomLength[T any](s []T, randomLen bool) []T {
-	var out = []T{}
+// ShuffleRandomLength shuffles s using r and, when randomLen is true, randomly
+// truncates the result. Truncation uses a coin-flip (geometric) distribution
+// biased toward keeping more elements: at least one element is always kept.
+// Passing a seeded Rand makes both the ordering and the truncation length
+// reproducible.
+func ShuffleRandomLength[T any](s []T, randomLen bool, r Rand) []T {
 	if len(s) == 0 {
 		return s
 	}
-	tmp := make([]T, len(s))
-	_ = copy(tmp, s)
-	var n int
-	if randomLen {
-		n = RandRange(1, len(tmp))
-	} else {
-		n = len(tmp)
-	}
-	for len(out) < n {
-		pick := RandRange(0, len(tmp)-1)
-		out = append(out, tmp[pick])
-		tmp = remove(tmp, pick)
-	}
-	return out
-}
 
-func remove[T any](s []T, index int) []T {
-	ret := make([]T, 0)
-	ret = append(ret, s[:index]...)
-	return append(ret, s[index+1:]...)
+	result := make([]T, len(s))
+	copy(result, s)
+
+	r.Shuffle(len(result), func(i, j int) {
+		result[i], result[j] = result[j], result[i]
+	})
+
+	if randomLen {
+		// Each coin flip decides whether to drop one more element from the
+		// end. This keeps at least one element and is biased toward keeping
+		// more, which is safer for handshake compatibility than uniform
+		// truncation.
+		n := len(result)
+		for n > 1 && r.Intn(2) == 1 {
+			n--
+		}
+		result = result[:n]
+	}
+
+	return result
 }
 
 // GenerateRandomP256PublicKey generates a random valid secp256r1 public key


### PR DESCRIPTION
Part 2 of the feature split from #18. Depends on #19 to compile.

Builds on the seeded-rand PR (#19). Adds a ServerHello hook that shuffles extension order to add some randomization to the server side, and randomizes the `ec_point_formats` extension on the `ClientHello`. Both go through the pluggable Rand, so they're reproducible under a seed.